### PR TITLE
Disable Style/RedundantBegin

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -848,7 +848,7 @@ Style/RandomWithOffset:
   Enabled: true
 
 Style/RedundantBegin:
-  Enabled: true
+  Enabled: false
 
 Style/RedundantCapitalW:
   Enabled: true


### PR DESCRIPTION
Discussed in slack:

> Can we turn off this Style/RedundantBegin rubocop check? [link to failing github actions check] I believe it’s pretty common practice for us to ||= assign to a begin… end block
>
> I assume this started failing with [link to failing pull] due to the if else block, but I find begin end to be more consistent with our style than to omit it just because there’s an if else block