### PR TITLE
Rubocop: Remove deprecated `Rails/ActionFilter` cop

### DIFF
--- a/rubocop_rails.yml
+++ b/rubocop_rails.yml
@@ -9,9 +9,6 @@ Style/SymbolProc:
     - respond_to
 
 ## Configuration for Rubocop Rails cops
-Rails/ActionFilter:
-  Enabled: true
-
 Rails/ActiveRecordAliases:
   Enabled: true
 


### PR DESCRIPTION
According to
https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsactionfilter:

> This cop is deprecated. Because the *_filter methods were removed in
> Rails 4.2, and that Rails version is no longer supported by RuboCop
> Rails. This cop will be removed in RuboCop Rails 3.0.
