### PR TITLE
Enable cops that were previously checked by pre-commit hook and CI

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -489,6 +489,9 @@ Style/EvalWithLocation:
 Style/EvenOdd:
   Enabled: true
 
+Style/ExpandPathArguments:
+  Enabled: true
+
 Style/ExponentialNotation:
   Enabled: true
 

--- a/rubocop_performance.yml
+++ b/rubocop_performance.yml
@@ -59,3 +59,9 @@ Performance/StringReplacement:
 
 Performance/TimesMap:
   Enabled: true
+
+Performance/UnfreezeString:
+  Enabled: true
+
+Performance/UriDefaultParser:
+  Enabled: true


### PR DESCRIPTION
These checks were run by the pre-commmit hook and in CI, but they weren't enabled in `.rubocop.yml`. The reason that they were run anyway was that we previously had a separate hard-coded list of checks in `util/hooks/pre_commit_rubocop_config.yml`, but we're getting rid of it to simplify things.

See https://github.com/academia-edu/academia-app/pull/35737#issue-2379162371 for how I determined that these cops should be enabled.