### PR TITLE
Move FactoryBot cop to separate file

### DIFF
--- a/rubocop_factory_bot.yml
+++ b/rubocop_factory_bot.yml
@@ -1,0 +1,2 @@
+FactoryBot/AttributeDefinedStatically:
+  Enabled: true

--- a/rubocop_rspec.yml
+++ b/rubocop_rspec.yml
@@ -54,9 +54,6 @@ RSpec/ExpectActual:
 RSpec/ExpectOutput:
   Enabled: true
 
-RSpec/FactoryBot/AttributeDefinedStatically:
-  Enabled: true
-
 RSpec/FilePath:
   Enabled: true
   CustomTransform:


### PR DESCRIPTION
After this, we should move start using the `rubocop_factory_bot.yml` config file in `academia-app/.rubocop.yml`.

If it were down to me, I would've named the file `rubocop_factorybot.yml`, but I'm following the name of the corresponding gem.