### PR TITLE
RuboCop Rails: Use `plugins` instead of `require`

### DIFF
--- a/rubocop_rails.yml
+++ b/rubocop_rails.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rails
 
 ## Rails-related configuration for cops that *don't* come from Rubocop Rails


### PR DESCRIPTION
To avoid this warning:

```
rubocop-rails gem supports plugin, use `--plugin` instead of `--require`.
rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in /home/runner/work/academia-app/academia-app/.rubocop-https---raw-githubusercontent-com-academia-edu-linting-config-main-rubocop-rails-yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```
